### PR TITLE
Persist ChatGPT Temporary toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-TODO: create browser extention whitch will store temporary state for new chats
+# AutoTemp Firefox Extension
+
+This extension remembers whether you enabled ChatGPT's built‑in **Temporary** toggle. When you switch the toggle on, the setting is saved and automatically re‑applied for every new chat so you don't need to click it again. The state is stored in `browser.storage.local`.
+
+## Development
+
+1. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on** and select the `manifest.json` file from this folder.
+3. The extension has no popup UI. Simply enable **Temporary** in the ChatGPT interface once – the extension will keep that choice for future chats.
+
+The code follows basic Manifest V3 patterns and uses `browser.storage.local` to persist the toggle state.
+
+Icons are not included in the repository to avoid committing binary assets. If desired, add your own icon files in an `icons/` directory and reference them from `manifest.json`.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,50 @@
+(function() {
+  const KEY = 'tempMode';
+
+  function findToggle() {
+    const candidates = Array.from(document.querySelectorAll('button, input'));
+    return candidates.find(el => /temporary/i.test(el.textContent || '') || /temporary/i.test(el.getAttribute('aria-label') || ''));
+  }
+
+  function isOn(el) {
+    return el.getAttribute('aria-pressed') === 'true' ||
+           el.getAttribute('aria-checked') === 'true' ||
+           el.classList.contains('active') ||
+           (el.checked === true);
+  }
+
+  function storeState(on) {
+    browser.storage.local.set({ [KEY]: on });
+  }
+
+  function applyState(el) {
+    browser.storage.local.get(KEY).then(({ tempMode }) => {
+      const enabled = Boolean(tempMode);
+      if (enabled && el && !isOn(el)) {
+        el.click();
+      }
+    });
+  }
+
+  function initWithToggle(el) {
+    applyState(el);
+    if (!el._autotemp_bound) {
+      el._autotemp_bound = true;
+      el.addEventListener('click', () => setTimeout(() => storeState(isOn(el)), 50));
+    }
+  }
+
+  const observer = new MutationObserver(() => {
+    const toggle = findToggle();
+    if (toggle) {
+      initWithToggle(toggle);
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+
+  // Initial run in case the toggle is already present
+  const initialToggle = findToggle();
+  if (initialToggle) {
+    initWithToggle(initialToggle);
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Temporary State",
+  "version": "1.0",
+  "description": "Persist and apply temporary chat mode for ChatGPT.",
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["contentScript.js"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- remove icon files and update README to note no binaries
- simplify manifest without icon references
- keep content script for storing ChatGPT's Temporary state

## Testing
- `node -e "require('fs').readFileSync('contentScript.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68889629cb588332942b38d9be1833ab