### PR TITLE
Limit PR workflow to QQRM

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,12 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    if: github.actor == 'QQRM'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Running CI for trusted user"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ The command creates a `.zip` archive inside a `web-ext-artifacts` folder. To dis
 ## Automated Build and Release
 
 A GitHub Actions workflow builds the extension whenever a tag starting with `v` is pushed. The pipeline uses `web-ext` to package the code and publishes the resulting `.xpi` file as an artifact of the corresponding GitHub Release. You can also trigger the workflow manually via the **Run workflow** button in the Actions tab.
+
+## Pull Request Checks
+
+Only pull requests opened by the `QQRM` account run CI jobs. The check is defined in `.github/workflows/pr.yml`. Pull requests from other users skip all pipelines, leaving merging to be controlled by repository protections.
+


### PR DESCRIPTION
## Summary
- restrict PR workflow to run only for user `QQRM`
- clarify README about the single trusted account

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b893836f883328142e6fab55365cc