### PR TITLE
Add build artifact to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,8 +5,24 @@ on:
 
 jobs:
   build:
-    if: github.actor == 'QQRM'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Running CI for trusted user"
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install web-ext
+        run: npm install --global web-ext
+      - name: Build extension
+        run: web-ext build
+      - name: Rename artifact
+        run: |
+          FILE=$(ls web-ext-artifacts/*.zip | head -n 1)
+          mv "$FILE" "${FILE%.zip}.xpi"
+          echo "ARTIFACT=${FILE%.zip}.xpi" >> "$GITHUB_ENV"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: ${{ env.ARTIFACT }}

--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ A GitHub Actions workflow builds the extension whenever a tag starting with `v` 
 
 ## Pull Request Checks
 
-Only pull requests opened by the `QQRM` account run CI jobs. The check is defined in `.github/workflows/pr.yml`. Pull requests from other users skip all pipelines, leaving merging to be controlled by repository protections.
+Every pull request triggers the CI workflow defined in `.github/workflows/pr.yml`. The job packages the extension with `web-ext` and uploads the resulting `.xpi` as a build artifact. You can download the artifact from the **Checks** tab of the pull request to test the extension before merging.
 


### PR DESCRIPTION
## Summary
- run CI for all pull requests
- package extension with `web-ext` during PR jobs
- document that every pull request uploads an `.xpi` artifact

## Testing
- `npm install --global web-ext`
- `web-ext build`


------
https://chatgpt.com/codex/tasks/task_e_688d4c3fb19c83329a5ce1aba2be51a8