### PR TITLE
Fix release workflow tag handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.0)'
+        required: true
 
 jobs:
   build:
@@ -24,6 +28,15 @@ jobs:
           FILE=$(ls web-ext-artifacts/*.zip | head -n 1)
           mv "$FILE" "${FILE%.zip}.xpi"
           echo "ARTIFACT=${FILE%.zip}.xpi" >> "$GITHUB_ENV"
+      - name: Set tag name
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "TAG_NAME=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          else
+            echo "TAG_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          fi
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -33,5 +46,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}
+          tag_name: ${{ env.TAG_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- allow manual workflow dispatch to supply a tag
- use the input or current ref to name the release tag

## Testing
- `npm install --global web-ext`
- `web-ext build`


------
https://chatgpt.com/codex/tasks/task_e_688d5485e94c833294472da6c2959d41