### PR TITLE
Update release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Build and Release Extension
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
+  pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -29,6 +32,7 @@ jobs:
           mv "$FILE" "${FILE%.zip}.xpi"
           echo "ARTIFACT=${FILE%.zip}.xpi" >> "$GITHUB_ENV"
       - name: Set tag name
+        if: github.event_name != 'pull_request'
         run: |
           if [ -n "${{ github.event.inputs.tag }}" ]; then
             echo "TAG_NAME=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
@@ -43,6 +47,7 @@ jobs:
           name: extension
           path: ${{ env.ARTIFACT }}
       - name: Create GitHub release
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.ARTIFACT }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The command creates a `.zip` archive inside a `web-ext-artifacts` folder. To dis
 
 ## Automated Build and Release
 
-A GitHub Actions workflow builds the extension whenever a tag starting with `v` is pushed. The pipeline uses `web-ext` to package the code and publishes the resulting `.xpi` file as an artifact of the corresponding GitHub Release. You can also trigger the workflow manually via the **Run workflow** button in the Actions tab.
+A GitHub Actions workflow builds the extension whenever a tag is pushed, a release is published, or the workflow is triggered manually. The pipeline uses `web-ext` to package the code and publishes the resulting `.xpi` file as an artifact of the corresponding GitHub Release. You can also start the workflow manually from the **Actions** tab.
 
 ## Pull Request Checks
 


### PR DESCRIPTION
## Summary
- build an XPI on every PR and any tag
- only create GitHub release when not running for a PR
- document new workflow behavior

## Testing
- `npm install --global web-ext`
- `web-ext build`

------
https://chatgpt.com/codex/tasks/task_e_688d5637ed288332ab1bc8f42d363d2f