### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
         description: 'Release tag (e.g., v1.0)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable write permission for release workflow so softprops/action-gh-release can create a release

## Testing
- `npm install --global web-ext`
- `web-ext build`

------
https://chatgpt.com/codex/tasks/task_e_688d5c0c0a148332bba1c7ae4d0da9cd