### PR TITLE
feat: add cross-browser storage wrapper

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,6 @@
 (function() {
   const KEY = 'tempMode';
+  const storage = (typeof browser !== 'undefined' && browser.storage) ? browser.storage : chrome.storage;
 
   function findToggle() {
     const candidates = Array.from(document.querySelectorAll('button, input'));
@@ -14,11 +15,11 @@
   }
 
   function storeState(on) {
-    browser.storage.local.set({ [KEY]: on });
+    storage.local.set({ [KEY]: on });
   }
 
   function applyState(el) {
-    browser.storage.local.get(KEY).then(({ tempMode }) => {
+    storage.local.get(KEY).then(({ tempMode }) => {
       const enabled = Boolean(tempMode);
       if (enabled && el && !isOn(el)) {
         el.click();


### PR DESCRIPTION
## Summary
- add a `storage` wrapper that prefers `browser.storage` and falls back to `chrome.storage`
- refactor to use the new wrapper instead of direct `browser.storage` calls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dda0add148332bc6bbf5ea0cbae28