### PR TITLE
Add logging to state storage and retrieval

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -15,14 +15,19 @@
   }
 
   function storeState(on) {
+    log('storeState', on);
     storage.local.set({ [KEY]: on });
   }
 
   function applyState(el) {
     storage.local.get(KEY).then(({ tempMode }) => {
       const enabled = Boolean(tempMode);
+      log('retrieved state', enabled);
       if (enabled && el && !isOn(el)) {
+        log('click toggle to enable');
         el.click();
+      } else {
+        log('toggle already enabled');
       }
     });
   }


### PR DESCRIPTION
## Summary
- add state logging inside `storeState`
- log retrieval and enable/skip actions in `applyState`

## Testing
- `node --check contentScript.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0552de7483329fe9ada87ba26087