### PR TITLE
Log DOM changes in MutationObserver

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -36,9 +36,12 @@
   }
 
   const observer = new MutationObserver(() => {
+    log('DOM changed');
     const toggle = findToggle();
     if (toggle) {
       initWithToggle(toggle);
+    } else {
+      log('toggle not found after DOM change');
     }
   });
   observer.observe(document.documentElement, { childList: true, subtree: true });


### PR DESCRIPTION
## Summary
- log DOM changes
- log when toggle is missing after DOM changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0551324883329d075b4a278e33e7