### PR TITLE
Add logging helper to content script

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,3 +1,6 @@
+function log(...args) { console.log('[autotemp]', ...args); }
+log('content script loaded');
+
 (function() {
   const KEY = 'tempMode';
   const storage = (typeof browser !== 'undefined' && browser.storage) ? browser.storage : chrome.storage;


### PR DESCRIPTION
## Summary
- add simple log function and log when content script loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e054c59bc8332874c18bb4b9e99b2