### PR TITLE
feat: refine temporary chat detection

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -7,14 +7,18 @@ log('content script loaded');
 
   function findToggle() {
     log('searching toggle');
-    const candidates = Array.from(document.querySelectorAll('button, input'));
-    const el = candidates.find(el => /temporary/i.test(el.textContent || '') || /temporary/i.test(el.getAttribute('aria-label') || ''));
+    const el = document.querySelector('#conversation-header-actions button[aria-label*="temporary chat"]') ||
+              Array.from(document.querySelectorAll('button, input')).find(el =>
+                /temporary/i.test(el.textContent || '') ||
+                /temporary/i.test(el.getAttribute('aria-label') || '')
+              );
     if (el) log('toggle found', el);
     return el;
   }
 
   function isOn(el) {
-    return el.getAttribute('aria-pressed') === 'true' ||
+    return el.getAttribute('aria-label') === 'Turn off temporary chat' ||
+           el.getAttribute('aria-pressed') === 'true' ||
            el.getAttribute('aria-checked') === 'true' ||
            el.classList.contains('active') ||
            (el.checked === true);


### PR DESCRIPTION
## Summary
- search for temporary chat toggle using specific conversation-header selector
- treat aria-label "Turn off temporary chat" as an active state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5c5614588332bd78af330b50c1a6