### PR TITLE
use MutationObserver for toggle state updates

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -48,7 +48,20 @@ log('content script loaded');
     if (!el._autotemp_bound) {
       log('bind click');
       el._autotemp_bound = true;
-      el.addEventListener('click', () => setTimeout(() => storeState(isOn(el)), 50));
+      el.addEventListener(
+        'click',
+        () => {
+          const observer = new MutationObserver(() => {
+            storeState(isOn(el));
+            observer.disconnect();
+          });
+          observer.observe(el, {
+            attributes: true,
+            attributeFilter: ['aria-pressed', 'aria-checked', 'class'],
+          });
+        },
+        { capture: true }
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- replace delayed storage update with MutationObserver watching the toggle's aria attributes and class

## Testing
- `node --check contentScript.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b35f78083329b9d941aae4f8d18