### PR TITLE
Use synthetic mouse events to toggle

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -56,13 +56,19 @@ log('content script loaded');
     storage.local.set({ [KEY]: on });
   }
 
+  function emulateClick(el) {
+    ['mousedown', 'mouseup', 'click'].forEach(type =>
+      el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }))
+    );
+  }
+
   async function applyState(el) {
     const { tempMode } = await getStoredState();
     const enabled = Boolean(tempMode);
     log('retrieved state', enabled);
     if (enabled && el && !isOn(el)) {
       log('click toggle to enable');
-      el.click();
+      emulateClick(el);
     } else {
       log('toggle already enabled');
     }


### PR DESCRIPTION
## Summary
- Add an `emulateClick` helper that dispatches mousedown, mouseup, and click events.
- Replace direct `el.click()` usage in `applyState` with `emulateClick` to trigger the full event sequence.

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e7beb5b3483329e13103db0f966e0