### PR TITLE
Use site-level temporary mode state

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -84,18 +84,22 @@ log('контент-скрипт загружен');
         'click',
         () => {
           log('пользователь нажал переключатель временного чата');
-          const observer = new MutationObserver(() => {
-            storeState(isOn(el));
-            observer.disconnect();
-          });
-          observer.observe(el, {
-            attributes: true,
-            attributeFilter: ['aria-pressed', 'aria-checked', 'class'],
-          });
+          setTimeout(() => storeState(siteTempMode()), 0);
         },
         { capture: true }
       );
     }
+  }
+
+  if (document.body) {
+    const bodyObserver = new MutationObserver(() => {
+      log('атрибут data-temporary-mode изменился');
+      storeState(siteTempMode());
+    });
+    bodyObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['data-temporary-mode'],
+    });
   }
 
   const observer = new MutationObserver(() => {


### PR DESCRIPTION
## Summary
- Persist temporary chat state using site-level `data-temporary-mode`/cookie instead of toggle attributes
- Track `data-temporary-mode` changes on `<body>` to handle programmatic toggles

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8413a748833294afd12d338ccff6