### PR TITLE
Handle errors when applying saved state

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -74,9 +74,13 @@ log('контент-скрипт загружен');
     }
   }
 
-  function initWithToggle(el) {
+  async function initWithToggle(el) {
     log('применяем сохранённое состояние');
-    applyState(el);
+    try {
+      await applyState(el);
+    } catch (error) {
+      log('ошибка при чтении сохранённого состояния', error);
+    }
     if (!el._autotemp_bound) {
       log('подписываемся на нажатие переключателя');
       el._autotemp_bound = true;


### PR DESCRIPTION
## Summary
- await `applyState` in `initWithToggle` so initialization waits for stored state
- log errors when reading saved state to aid debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e84d4cb3483329e1679fbb7af25b6